### PR TITLE
Initial .travis.yml addition

### DIFF
--- a/ci-travis/.travis.yml
+++ b/ci-travis/.travis.yml
@@ -1,0 +1,33 @@
+language: go
+
+services:
+  - docker
+  
+before_install:
+  - export GLIDE_VERSION=v0.12.3
+  - ls $GOPATH/src/
+  - wget "https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.tar.gz"
+  - mkdir -p $HOME/bin
+  - tar -vxz -C $HOME/bin --strip=1 -f glide-$GLIDE_VERSION-linux-amd64.tar.gz
+  - export PATH="$HOME/bin:$PATH" GLIDE_HOME="$HOME/.glide"
+
+install:
+  - cd $GOPATH/src/
+  - mkdir k8s.io && cd k8s.io
+  - git clone https://github.com/kubernetes/helm
+  - cd helm && make bootstrap build
+  - mv bin/helm $HOME/bin
+
+script:
+  - cd $TRAVIS_BUILD_DIR
+  - bash setup_kubeadm.sh  
+  - $HOME/gopath/src/k8s.io/helm/bin/tiller &
+  - export HELM_HOST=localhost:44134
+  - helm init --client-only
+  - helm version
+  - helm serve &
+  - sleep 1m
+  - helm repo add local http://localhost:8879/charts
+  - helm repo update
+  - make
+  - bash dry_run_charts.sh

--- a/ci-travis/dry_run_charts.sh
+++ b/ci-travis/dry_run_charts.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+for chart in *.tgz; do
+  echo "Running helm install --dry-run --debug on $chart";
+  helm install --dry-run --debug local/$chart;
+done
+

--- a/ci-travis/setup_kubeadm.sh
+++ b/ci-travis/setup_kubeadm.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker run -it -e quay.io/attcomdev/kubeadm-ci:latest --name kubeadm-ci --privileged=true -d --net=host --security-opt seccomp:unconfined --cap-add=SYS_ADMIN -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /var/run/docker.sock:/var/run/docker.sock quay.io/attcomdev/kubeadm-ci:latest /sbin/init
+
+docker exec kubeadm-ci kubeadm.sh


### PR DESCRIPTION
This adds .travis.yml and helper scripts for potential use on the
openstack-helm repo.  The workflow is as follows: install Glide as
a requirement for kubernetes-helm, build helm from source (this is
required to run tiller locally), deploy the kubeadm-ci container,
execute the config script, run tiller locally, run `make`, then runs a
script that runs `helm install --dry-run --debug {x}`

See https://travis-ci.org/wilkers-steve/openstack-helm for verified
output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/aic-ci/4)
<!-- Reviewable:end -->
